### PR TITLE
README: Clarify Xcode dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a [Homebrew][brew] tap for formulae for software developed by Wix.
 Setup
 -----
 
-Using these formulae requires Homebrew, which in turn requires Xcode. If you
+Using these formulae requires Homebrew and Xcode. If you
 have not yet installed Homebrew, a quick summary is at the end of this
 document.
 


### PR DESCRIPTION
Homebrew needs [CLT](https://docs.brew.sh/Installation.html#requirements) but it doesn’t depend on Xcode per se: I don’t have Xcode and yet I can use Homebrew. Some formulae *may* need Xcode to be installed, such as [`applesimutils.rb`](https://github.com/wix/homebrew-brew/blob/94437e72233ca111487d590363e8f26ee2f6d1bc/applesimutils.rb#L8) in this tap.