### PR TITLE
fix readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ formulae. For example, to install the latest version of the Apple simulator util
 ```shell
 brew tap wix/brew
 brew update
-brew install wix/applesimutils
+brew install applesimutils
 ```
 
 To upgrade software:


### PR DESCRIPTION
```
mac ~ $ brew install wix/applesimutils
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
Error: No available formula or cask with the name "wix/applesimutils".
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
mac ~ $ brew install applesimutils
==> Installing applesimutils from wix/brew
==> Downloading https://github.com/wix/AppleSimulatorUtils/releases/download/0.9/applesimutils-0.9.catalina.bottle.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/86659796/230ce100-3022-11eb-83f4-b94f41475fde?X-
```