### PR TITLE
Fix styling for detox-instruments.rb

### DIFF
--- a/Casks/detox-instruments.rb
+++ b/Casks/detox-instruments.rb
@@ -1,12 +1,12 @@
-cask 'detox-instruments' do
+cask "detox-instruments" do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/wix/DetoxInstruments/releases/download/1.15.13062/DetoxInstruments-v1.15.b13062.zip'
-  name 'Detox Instruments'
-  homepage 'https://github.com/wix/DetoxInstruments'
+  url "https://github.com/wix/DetoxInstruments/releases/download/1.15.13062/DetoxInstruments-v1.15.b13062.zip"
+  name "Detox Instruments"
+  homepage "https://github.com/wix/DetoxInstruments"
 
-  depends_on macos: '>= :catalina'
-  
-  app 'Detox Instruments.app'
+  depends_on macos: ">= :catalina"
+
+  app "Detox Instruments.app"
 end


### PR DESCRIPTION
Following #6 - this fixes styling for `detox-instruments.rb` (i.e. ran `brew style --fix Casks/deetox-instruments.rb`).