### PR TITLE
supraworker: resolve warning from homebrew

### DIFF
--- a/Formula/supraworker.rb
+++ b/Formula/supraworker.rb
@@ -6,7 +6,6 @@ class Supraworker < Formula
   version "0.4.4"
   sha256 "f5ee45f8f1dd4c61a7ea668bd74167b3629c83a188d953f19ab985c08b24dbf2"
 
-  bottle :unneeded
   conflicts_with "supraworker"
 
   def install


### PR DESCRIPTION
Resolves this warning: 

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the wix/brew tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/wix/homebrew-brew/Formula/supraworker.rb:9
```

EDITED: Fixes #12