### PR TITLE
Fix AppleSimUtils SHA256.

### DIFF
--- a/Formula/applesimutils.rb
+++ b/Formula/applesimutils.rb
@@ -13,9 +13,9 @@ class Applesimutils < Formula
 
     sha256 arm64_big_sur: "49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18"
     sha256 catalina:      "0abd6a10f0fa5f7008799c06c59836b690ca2707bf9cb8a62095ecbd87363e6d"
-    sha256 mojave:        "0abd6a10f0fa5f7008799c06c59836b690ca2707bf9cb8a62095ecbd87363e6d"
-    sha256 high_sierra:   "0abd6a10f0fa5f7008799c06c59836b690ca2707bf9cb8a62095ecbd87363e6d"
-    sha256 sierra:        "0abd6a10f0fa5f7008799c06c59836b690ca2707bf9cb8a62095ecbd87363e6d"
+    sha256 mojave:        "49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18"
+    sha256 high_sierra:   "49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18"
+    sha256 sierra:        "49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18"
     sha256 big_sur:       "49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18"
   end
 


### PR DESCRIPTION
```
sha256sum applesimutils-0.9.6.*                    
49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18  applesimutils-0.9.6.arm64_big_sur.bottle.tar.gz
49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18  applesimutils-0.9.6.big_sur.bottle.tar.gz
0abd6a10f0fa5f7008799c06c59836b690ca2707bf9cb8a62095ecbd87363e6d  applesimutils-0.9.6.catalina.bottle.tar.gz
49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18  applesimutils-0.9.6.high_sierra.bottle.tar.gz
49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18  applesimutils-0.9.6.mojave.bottle.tar.gz
49e54d54a7ab60829b89ba9c8864d02be2a1adc2c3334575a4143d4a828cdc18  applesimutils-0.9.6.sierra.bottle.tar.gz
```